### PR TITLE
Fix parser tests when running in a french locale

### DIFF
--- a/tests/FSharp.Explicit.Json.Tests/ParserTests.fs
+++ b/tests/FSharp.Explicit.Json.Tests/ParserTests.fs
@@ -3,6 +3,7 @@
 open Expecto
 open Expecto.Flip.Expect
 open System
+open System.Globalization
 open System.Text.Json
 open FsToolkit.ErrorHandling
 open FSharp.Explicit.Json.Parse
@@ -166,12 +167,12 @@ let tests =
             testCase "Parse single" <| fun _ ->
                 let number = Single.MaxValue
                 let expected = Ok number
-                let json = number.ToString()
+                let json = number.ToString(CultureInfo.InvariantCulture)
                 let actual = parse json Parse.single
                 equal $"{json} -> Ok {json}" expected actual
 
             testCase "Parse out of range single" <| fun _ ->
-                let json = $"{Single.MaxValue.ToString()}0"
+                let json = $"{Single.MaxValue.ToString(CultureInfo.InvariantCulture)}0"
                 let expected = Ok Single.PositiveInfinity
                 let actual = parse json Parse.single
                 equal (sprintf "%A -> %A" json expected) expected actual
@@ -179,12 +180,12 @@ let tests =
             testCase "Parse double" <| fun _ ->
                 let number = Double.MaxValue
                 let expected = Ok number
-                let json = number.ToString()
+                let json = number.ToString(CultureInfo.InvariantCulture)
                 let actual = parse json Parse.double
                 equal $"{json} -> Ok {json}" expected actual
 
             testCase "Parse out of range double" <| fun _ ->
-                let json = $"{Double.MaxValue.ToString()}0"
+                let json = $"{Double.MaxValue.ToString(CultureInfo.InvariantCulture)}0"
                 let expected = Ok Double.PositiveInfinity
                 let actual = parse json Parse.double
                 equal (sprintf "%A -> %A" json expected) expected actual
@@ -192,12 +193,12 @@ let tests =
             testCase "Parse deciaml" <| fun _ ->
                 let number = System.Decimal.MaxValue
                 let expected = Ok number
-                let json = number.ToString()
+                let json = number.ToString(CultureInfo.InvariantCulture)
                 let actual = parse json Parse.decimal
                 equal $"{json} -> Ok {json}" expected actual
 
             testCase "Parse out of range decimal" <| fun _ ->
-                let json = $"{Decimal.MaxValue.ToString()}0"
+                let json = $"{Decimal.MaxValue.ToString(CultureInfo.InvariantCulture)}0"
                 let expected = ValueOutOfRange (typeof<decimal>, json) |> leftError []
                 let actual = parse json Parse.decimal
                 equal (sprintf "%A -> %A" json expected) expected actual


### PR DESCRIPTION
number.ToString() uses a comma instead of a full stop when running in a French locale

This fixes the parser tests when running in a French locale.

It may be preferable to set the culture globally, if possible.
I don't know whether number.ToString() is problematic for integral values in some locales.
I don't know about timeStamp.ToString() either.

I still have one test error on Windows
```
Running tests!
[22:29:54 INF] EXPECTO? Running tests... <Expecto>
Error [{ path = []
         reason = UserError "Unexpected type when matching on value" }]
[22:29:54 ERR] All Tests.Render Tests.Sample failed in 00:00:00.0910000.
JSON is equal. String does not match at position 1. Expected char: '\010', but got '\013'.
expected:
{
  "alpha": {
    "beta": "1"
  },
  "gamma": "2"
}
  actual:
{
  "alpha": {
    "beta": "1"
  },
  "gamma": "2"
}
   at FSharp.Explicit.Json.RenderTests.tests@37.Invoke(Unit _arg1) in C:\Users\jpage\source\jpeg729\FSharp.Explicit.Json\tests\FSharp.Explicit.Json.Tests\RenderTests.fs:line 55
   at Expecto.Impl.execTestAsync@569-1.Invoke(Unit unitVar)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 447
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 104 <Expecto>
[22:29:54 INF] EXPECTO! 51 tests run in 00:00:00.2599435 for All Tests - 50 passed, 0 ignored, 1 failed, 0 errored.  <Expecto>
```